### PR TITLE
fix: Allow all origins for CORS and use env variables

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -13,16 +13,7 @@ const app = express();
 
 // Configuration CORS simplifiée
 app.use((req, res, next) => {
-  const allowedOrigins = [
-    'https://todolist-17q1wd367-devco01s-projects.vercel.app',
-    'http://localhost:5173'
-  ];
-  
-  const origin = req.headers.origin;
-  if (allowedOrigins.includes(origin)) {
-    res.setHeader('Access-Control-Allow-Origin', origin);
-  }
-
+  res.setHeader('Access-Control-Allow-Origin', '*');  // Autoriser toutes les origines
   res.setHeader('Access-Control-Allow-Methods', 'GET,POST,PUT,DELETE,OPTIONS,PATCH');
   res.setHeader('Access-Control-Allow-Headers', 'Content-Type,Authorization,X-Requested-With');
   res.setHeader('Access-Control-Allow-Credentials', 'false');

--- a/backend/vercel.json
+++ b/backend/vercel.json
@@ -12,7 +12,7 @@
       "dest": "server.js",
       "methods": ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
       "headers": {
-        "Access-Control-Allow-Origin": "https://todolist-17q1wd367-devco01s-projects.vercel.app",
+        "Access-Control-Allow-Origin": "*",
         "Access-Control-Allow-Methods": "GET,POST,PUT,DELETE,OPTIONS,PATCH",
         "Access-Control-Allow-Headers": "X-Requested-With,Content-Type,Accept,Authorization",
         "Access-Control-Allow-Credentials": "false"

--- a/frontend/src/utils/axios.js
+++ b/frontend/src/utils/axios.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
 const baseURL = import.meta.env.PROD 
-  ? 'https://todolist-17q1wd367-devco01s-projects.vercel.app'  // URL correcte de l'API
+  ? import.meta.env.VITE_API_URL  // Utiliser l'URL depuis les variables d'environnement
   : 'http://localhost:3000/api';
 
 const instance = axios.create({


### PR DESCRIPTION
- Set Access-Control-Allow-Origin to * in backend
- Update Vercel configuration to allow all origins
- Use environment variable for API URL in frontend

This fixes CORS issues with Vercel preview deployments.